### PR TITLE
rgw/admin: add more options for creating subusers

### DIFF
--- a/rgw/admin/subuser.go
+++ b/rgw/admin/subuser.go
@@ -50,7 +50,7 @@ func (api *API) CreateSubuser(ctx context.Context, user User, subuser SubuserSpe
 	}
 	// valid parameters not supported by go-ceph: access-key, gen-access-key
 	v := valueToURLParams(user, []string{"uid"})
-	addToURLParams(&v, subuser, []string{"subuser", "access", "secret-key", "generate-secret", "key-type"})
+	addToURLParams(&v, subuser, []string{"subuser", "access", "access-key", "secret-key", "generate-secret", "gen-access-key", "key-type"})
 	_, err := api.call(ctx, http.MethodPut, "/user", v)
 	if err != nil {
 		return err

--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -42,11 +42,13 @@ type SubuserSpec struct {
 	Access SubuserAccess `json:"permissions" url:"access"`
 
 	// these are always nil in answers, they are only relevant in requests
-	GenerateKey *bool   `json:"-" url:"generate-key"`
-	SecretKey   *string `json:"-" url:"secret-key"`
-	Secret      *string `json:"-" url:"secret"`
-	PurgeKeys   *bool   `json:"-" url:"purge-keys"`
-	KeyType     *string `json:"-" url:"key-type"`
+	GenerateKey       *bool   `json:"-" url:"generate-key"`
+	GenerateAccessKey *bool   `json:"-" url:"gen-access-key"`
+	AccessKey         *string `json:"-" url:"access-key"`
+	SecretKey         *string `json:"-" url:"secret-key"`
+	Secret            *string `json:"-" url:"secret"`
+	PurgeKeys         *bool   `json:"-" url:"purge-keys"`
+	KeyType           *string `json:"-" url:"key-type"`
 }
 
 // SubuserAccess represents an access level for a subuser


### PR DESCRIPTION
Add access-key and gen-access-key URL parameters
when creating subusers.

Based on the RGW source code: https://github.com/ceph/ceph/blob/2b14a6730a7d525fdcd14d23af310045ee4bbd6b/src/rgw/driver/rados/rgw_rest_user.cc#L526-L532

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
